### PR TITLE
Run async in webhook mode

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 History
 -------
+1.1.0 (unreleased)
+++++++++++++++++++
+* Run functions decorated with ``@run_async`` in webhook mode [Nachtalb]
+
 1.0.0 (2017-05-25)
 ++++++++++++++++++
 * IMPORTANT: If you upgrade from a previous version, you MUST change how to include django_telegrambot.urls and settings.py.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 1.1.0 (unreleased)
 ++++++++++++++++++
 * Run functions decorated with ``@run_async`` in webhook mode [Nachtalb]
+* Define per bot how many ``@async_run`` workers to use with ``ASYNC_WORKERS``  [Nachtalb]
 
 1.0.0 (2017-05-25)
 ++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,9 @@ And set your bots::
                    #'POLL_READ_LATENCY':(Optional[float|int]), # Grace time in seconds for receiving the reply from
         		                   #server. Will be added to the `timeout` value and used as the read timeout from
                                    #server (Default: 2).
+
+                   #'ASYNC_WORKERS':(Optional[int]), # Amount of threads in the thread pool for functions
+                                   #decorated with ``@run_async``.(Default: 4).
                 },
                 #Other bots here with same structure.
             ],

--- a/django_telegrambot/apps.py
+++ b/django_telegrambot/apps.py
@@ -169,7 +169,7 @@ class DjangoTelegramBot(AppConfig):
             allowed_updates = b.get('ALLOWED_UPDATES', None)
             timeout = b.get('TIMEOUT', None)
             proxy = b.get('PROXY', None)
-            workers = 4
+            workers = b.get('ASYNC_WORKERS', 4)
 
             if self.mode == WEBHOOK_MODE:
                 try:              


### PR DESCRIPTION
I found out that using ``@run_async`` in webhook mode lead into the nothingness of a queue that was not worked through. This is the webhook is not started via the ``updater.start_webhook`` as it's done usually with ``python-telegram-bot``. So instead we call the underlying method ourselves. 

As addition, I added a settings parameter to define on a per bot basis how many workers the bot shall use. 

* Run functions decorated with ``@run_async`` in webhook mode
* Define per bot how many ``@async_run`` workers to use with ``ASYNC_WORKERS``