### PR TITLE
Fix error on startup when using MESSAGEQUEUE_ENABLED

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 History
 -------
+1.1.0 (unreleased)
+++++++++++++++++++
+* Fix error on startup when using ``MESSAGEQUEUE_ENABLED`` [Nachatlb]
+
 1.0.0 (2017-05-25)
 ++++++++++++++++++
 * IMPORTANT: If you upgrade from a previous version, you MUST change how to include django_telegrambot.urls and settings.py.

--- a/django_telegrambot/apps.py
+++ b/django_telegrambot/apps.py
@@ -170,7 +170,7 @@ class DjangoTelegramBot(AppConfig):
             proxy = b.get('PROXY', None)
             
             if self.mode == WEBHOOK_MODE:
-                try:              
+                try:
                     if b.get('MESSAGEQUEUE_ENABLED',False):
                         q = mq.MessageQueue(all_burst_limit=b.get('MESSAGEQUEUE_ALL_BURST_LIMIT',29),
                         all_time_limit_ms=b.get('MESSAGEQUEUE_ALL_TIME_LIMIT_MS',1024))
@@ -178,7 +178,7 @@ class DjangoTelegramBot(AppConfig):
                             request = Request(proxy_url=proxy['proxy_url'], urllib3_proxy_kwargs=proxy['urllib3_proxy_kwargs'], con_pool_size=b.get('MESSAGEQUEUE_REQUEST_CON_POOL_SIZE',8))
                         else:
                             request = Request(con_pool_size=b.get('MESSAGEQUEUE_REQUEST_CON_POOL_SIZE',8))
-                        bot = MQBot(token, request=request, mqueue=q)
+                        bot = MQBot(q, token=token, request=request)
                     else:
                         request = None
                         if proxy:


### PR DESCRIPTION
`MQBot`'s first argument is the message queue but the token was sent to it. And in addition to that, the message queue was set via the keyword argument `mqueue`. This resulted in a:
```
TypeError: __init__() got multiple values for argument 'mqueue'
```