### PR TITLE
add context based handlers for ptb12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,8 @@ And set your bots::
             'BOTS' : [
                 {
                    'TOKEN': '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11', #Your bot token.
+                   
+                   #'CONTEXT': True,  # Use context based handler functions
 
                    #'ALLOWED_UPDATES':(Optional[list[str]]), # List the types of
         						   #updates you want your bot to receive. For example, specify

--- a/django_telegrambot/apps.py
+++ b/django_telegrambot/apps.py
@@ -162,15 +162,16 @@ class DjangoTelegramBot(AppConfig):
 
         for b in bots_list:
             token = b.get('TOKEN', None)
+            context = b.get('CONTEXT', False)
             if not token:
                 break
 
             allowed_updates = b.get('ALLOWED_UPDATES', None)
             timeout = b.get('TIMEOUT', None)
             proxy = b.get('PROXY', None)
-            
+
             if self.mode == WEBHOOK_MODE:
-                try:              
+                try:
                     if b.get('MESSAGEQUEUE_ENABLED',False):
                         q = mq.MessageQueue(all_burst_limit=b.get('MESSAGEQUEUE_ALL_BURST_LIMIT',29),
                         all_time_limit_ms=b.get('MESSAGEQUEUE_ALL_TIME_LIMIT_MS',1024))
@@ -184,7 +185,7 @@ class DjangoTelegramBot(AppConfig):
                         if proxy:
                             request = Request(proxy_url=proxy['proxy_url'], urllib3_proxy_kwargs=proxy['urllib3_proxy_kwargs'])
                         bot = telegram.Bot(token=token, request=request)
-                        
+
                     DjangoTelegramBot.dispatchers.append(Dispatcher(bot, None, workers=0))
                     hookurl = '{}/{}/{}/'.format(webhook_site, webhook_base, token)
                     max_connections = b.get('WEBHOOK_MAX_CONNECTIONS', 40)
@@ -204,7 +205,7 @@ class DjangoTelegramBot(AppConfig):
 
             else:
                 try:
-                    updater = Updater(token=token, request_kwargs=proxy)
+                    updater = Updater(token=token, request_kwargs=proxy, use_context=context)
                     bot = updater.bot
                     bot.delete_webhook()
                     DjangoTelegramBot.updaters.append(updater)


### PR DESCRIPTION
I just added the use_context parameter to the creation of the Updater, to be able to use the new `handlerfunc(update, context)` style. The bool variable is read from the bots config in settings.py
```
DJANGO_TELEGRAMBOT = {
    ...
    'BOTS' : [
        {
           'TOKEN': xxx',
           'CONTEXT': True, # pass context to handler fucntions func(update, context)
          ...
```
If not set it stays False, which is also the default if no `use_context` is given. So this should be downwards compatible, at least for older bot code. The kwarg probably raise an error for older ptb versions. 
Howerver, should be easy to except that case and adjust the example project. Let me know when you want me to do that.