### PR TITLE
Update django.urls imports for newer Django

### DIFF
--- a/django_telegrambot/urls.py
+++ b/django_telegrambot/urls.py
@@ -1,5 +1,5 @@
 
-from django.conf.urls import url
+from django.urls import re_path
 from . import views
 from django.conf import settings
 
@@ -10,6 +10,6 @@ if not webhook_base.endswith("/"):
     webhook_base += "/"
 
 urlpatterns = [
-    url(r'admin/django-telegrambot/$', views.home, name='django-telegrambot'),
-    url(r'{}(?P<bot_token>.+?)/$'.format(webhook_base), views.webhook, name='webhook'),
+    re_path(r'admin/django-telegrambot/$', views.home, name='django-telegrambot'),
+    re_path(r'{}(?P<bot_token>.+?)/$'.format(webhook_base), views.webhook, name='webhook'),
 ]

--- a/sampleproject/bot/urls.py
+++ b/sampleproject/bot/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
-urlpatterns = [                                                                                                                      
-    url(r'^$', views.index, name='index'),
+urlpatterns = [
+    re_path(r'^$', views.index, name='index'),
 ]

--- a/sampleproject/sampleproject/urls.py
+++ b/sampleproject/sampleproject/urls.py
@@ -13,11 +13,11 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^', include('django_telegrambot.urls')),
-    url(r'^$', include('bot.urls')),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^', include('django_telegrambot.urls')),
+    re_path(r'^$', include('bot.urls')),
 ]


### PR DESCRIPTION
`django.conf.urls` was deprecated in Django 3 and removed in Django 4.